### PR TITLE
lint & fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ to install.
 To use this tool as a package, load as a function.
 
 ```python
-import cjeReportingTool
+import cjeReportingTool.cjeReportingTool as c
 
-cjeReportingTool.cjeReportingTool(path, outpath, split_str, prefix)
+c.cjeReportingTool(path, outpath, split_str, prefix)
 ```
 
 Each args:
@@ -90,7 +90,7 @@ print(n) ##2
 - Main program `main.py`
 
 ```text
-import cjeReportingTool as c
+import cjeReportingTool.cjeReportingTool as c
 
 c.cjeReportingTool('sample.py', 'out.md', '##', '>')
 ```

--- a/README.md
+++ b/README.md
@@ -1,74 +1,97 @@
 # cjeReportingTool
+
 ![example](./img/image.png "サンプル")
 
+This tool made for CJE(Chishiki Joho Enshu 3) class at Univ. Tsukuba, klis.
+This package converts source code comment to markdown text using split words.
 
-This Tool made for CJE(Chishiki Joho Enshu 3) class at Univ. Tsukuba, klis.  
-This package converts source code comment to markdown text using split words.  
+> ja:
+> 筑波大学 KLISのCJE3のマークダウン形式の小レポート用ライブラリです。
+> 特定の文字列`##`や`#$`等をコメントに用いると，その記号を用いたコード行末に書いたコメントのみを行番号と合わせて出力します。
 
->ja: 筑波大学 KLISのCJE3のマークダウン形式の小レポート用ライブラリです。特定の文字列`##`や`#$`等をコメントに用いると，その記号を用いたコード行末に書いたコメントのみを行番号と合わせて出力します。
+## Usage
 
-# Usage
+### Require
 
-## Require
 This package does not require on other any packages.
 
+### Installation
 
-## Installation
-This package runs on Python 3.6 or higher version. You can install it from PyPI via pip:  
+This package runs on Python 3.6 or higher version. You can install it from PyPI via pip:
+
+> ja:
 > pipからインストールすることができます。インストールするには以下のコマンドを使用します。
-```
+
+```bash
 pip install cjeReportingTool
 ```
 
 to install.
 
 ## Documentation
+
 To use the package, load as a function.
 
-```
+```python
 cjeReportingTool(path, outpath, split_str, prefix)
 ```
+
 ### Args
+
 - `path` Read file path
-- `outpaht` Export file path
+- `outpath` Export file path
 - `split_str` A symbol or string that separates comments from source code
 - `prefix` Prefixes to be written out
 
 ### Example
+
 - File
-```
+
+```text
 .
 ├── sample.py
 ├── out.md
 └── main.py
 ```
+
 ---
+
 - Read file `./sample.py`
-```
+
+```text
 1   # num
 2   i = 1 ##number
-3   n = i * 2 
+3   n = i * 2
 4   # output
 5   print(n) ##2
 ```
+
 - Main program `./main.py`
-```
+
+```text
 1   cjeReportingTool('sample.py', 'out.md', '##', '>')
 ```
+
 ---
+
 - Output file  `./out.md`
-```
+
+```text
 1   > 2: number
 2   
 3   > 5: 2
 ```
+
 ![example](./img/preview_ex.png "サンプル")
 
 ### Note
+
 `split_str` uses a string other than the spelling of the symbols used your python code.
-- Good: `##`, `#&`, `#$`, `#%`　　
+
+- Good: `##`, `#&`, `#$`, `#%`
 - Bad: `#` No difference from other comments　`$` That's not comment
 
-# License
-This software is released under the MIT License, see LICENSE.  
-show all https://github.com/murataka9/cjeReportingTool/blob/main/LICENSE
+## License
+
+This software is released under the MIT License, see LICENSE.
+show all <https://github.com/murataka9/cjeReportingTool/blob/main/LICENSE>

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ This package converts source code comment to markdown text using split words.
 > 筑波大学 KLISのCJE3のマークダウン形式の小レポート用ライブラリです。
 > 特定の文字列`##`や`#$`等をコメントに用いると，その記号を用いたコード行末に書いたコメントのみを行番号と合わせて出力します。
 
-## Usage
-
-### Require
+### Requirement
 
 This package does not require on other any packages.
 
@@ -28,22 +26,45 @@ pip install cjeReportingTool
 
 to install.
 
-## Documentation
+## Usage
 
-To use the package, load as a function.
+To use this tool as a package, load as a function.
 
 ```python
-cjeReportingTool(path, outpath, split_str, prefix)
+import cjeReportingTool
+
+cjeReportingTool.cjeReportingTool(path, outpath, split_str, prefix)
 ```
 
-### Args
+Each args:
 
 - `path` Read file path
 - `outpath` Export file path
 - `split_str` A symbol or string that separates comments from source code
 - `prefix` Prefixes to be written out
 
-### Example
+To use this command as a command,
+
+```bash
+$ cjerep -h
+usage: cjeReportingTool [-h] path outpath split_str prefix
+
+This Tool made for CJE(Chishiki Joho Enshu 3) class at Univ. Tsukuba, klis.
+This package converts source code comment to markdown text using split words.
+
+positional arguments:
+  path        Read file path
+  outpath     Export file path
+  split_str   A symbol or string that separates comments from source code
+  prefix      A Prefix to be written out
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+$ cjerep sample.py out.md
+```
+
+## Example
 
 - File
 
@@ -56,25 +77,27 @@ cjeReportingTool(path, outpath, split_str, prefix)
 
 ---
 
-- Read file `./sample.py`
+- Read file `sample.py`
 
-```text
-1   # num
-2   i = 1 ##number
-3   n = i * 2
-4   # output
-5   print(n) ##2
+```python
+# num
+i = 1 ##number
+n = i * 2
+# output
+print(n) ##2
 ```
 
-- Main program `./main.py`
+- Main program `main.py`
 
 ```text
-1   cjeReportingTool('sample.py', 'out.md', '##', '>')
+import cjeReportingTool as c
+
+c.cjeReportingTool('sample.py', 'out.md', '##', '>')
 ```
 
 ---
 
-- Output file  `./out.md`
+- Output file  `out.md`
 
 ```text
 1   > 2: number

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ This package converts source code comment to markdown text using split words.
 > 筑波大学 KLISのCJE3のマークダウン形式の小レポート用ライブラリです。
 > 特定の文字列`##`や`#$`等をコメントに用いると，その記号を用いたコード行末に書いたコメントのみを行番号と合わせて出力します。
 
-### Requirement
+## Requirement
 
 This package does not require on other any packages.
 
-### Installation
+## Installation
 
 This package runs on Python 3.6 or higher version. You can install it from PyPI via pip:
 
 > ja:
-> pipからインストールすることができます。インストールするには以下のコマンドを使用します。
+> このパッケージはPython 3.6以上で動作します。
+> またpipコマンドで以下のようにインストールできます。
 
 ```bash
 pip install cjeReportingTool


### PR DESCRIPTION
`README.md`のlintエラーと誤字修正です