### PR TITLE
CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,10 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# tmpfiles
+*.swp
+*.save
+
+# vscode
+*.vscode

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ c.cjeReportingTool('sample.py', 'out.md', '##', '>')
 `split_str` uses a string other than the spelling of the symbols used your python code.
 
 - Good: `##`, `#&`, `#$`, `#%`
-- Bad: `#` No difference from other comments　`$` That's not comment
+- Bad: `#` (No difference from other comments), `$` (That's not comment)
 
 ## License
 

--- a/cjeReportingTool/cjeReportingTool.py
+++ b/cjeReportingTool/cjeReportingTool.py
@@ -35,6 +35,7 @@ def cjeReportingTool(
             linenum_explanation[line_cout_str] = str(split_line[1])
 
         print('■{}%'.format(str(round(sequence_per, 2))), end='\r')
+
     print('')
 
     for line_num in linenum_explanation:

--- a/cjeReportingTool/cjeReportingTool.py
+++ b/cjeReportingTool/cjeReportingTool.py
@@ -7,6 +7,7 @@
 # This source code or any portion licensed by MIT
 # ===========================================#
 
+
 def cjeReportingTool(path, outpath, split_str, prefix):
 
     # 文字列へ強制変換
@@ -16,7 +17,7 @@ def cjeReportingTool(path, outpath, split_str, prefix):
     prefix = str(prefix)
 
     # シークエンスバー
-    seq, sequence_per, sequence_con = 0, 0, 0
+    sequence_per, sequence_con = 0, 0
     seq = sum(1 for line in open(path))
 
     # 指定ファイルを開く
@@ -26,7 +27,7 @@ def cjeReportingTool(path, outpath, split_str, prefix):
     line_cout = 1  # lineのカウントの初期化
     linenum_explanation = {}  # 行番号:説明文対辞書
 
-    # 1行づつ処理して指定語があったらsplitしてsplit_line[1]を辞書に登録
+    # 1行ずつ処理して指定語があったらsplitしてsplit_line[1]を辞書に登録
     for line in f:
         line = line.rstrip()
         sequence_con += 1

--- a/cjeReportingTool/cjeReportingTool.py
+++ b/cjeReportingTool/cjeReportingTool.py
@@ -1,48 +1,49 @@
-#========================================== #
+# ==========================================#
 # Project Name    : cjeReportingTool
 # File Name       : cjeReportingTool.py
 # Encoding        : utf-8
 # Creation Date   : 26-Jun-2021
- 
 # Copyright © 2021 kami; Takahito Murakami. All rights reserved.
 # This source code or any portion licensed by MIT
-#===========================================#
+# ===========================================#
 
 def cjeReportingTool(path, outpath, split_str, prefix):
-  #文字列へ強制変換
-  path = str(path)
-  outpath = str(outpath)
-  split_str = str(split_str)
-  prefix = str(prefix)
 
-  #シークエンスバー
-  seq, sequence_per, sequence_con= 0,0, 0
-  seq = sum(1 for line in open(path))
+    # 文字列へ強制変換
+    path = str(path)
+    outpath = str(outpath)
+    split_str = str(split_str)
+    prefix = str(prefix)
 
-  #指定ファイルを開く
-  f = open(path, 'r')
-  f2 = open(outpath, 'w')
+    # シークエンスバー
+    seq, sequence_per, sequence_con = 0, 0, 0
+    seq = sum(1 for line in open(path))
 
-  line_cout = 1 #lineのカウントの初期化
-  linenum_explanation = {} #行番号:説明文対辞書
+    # 指定ファイルを開く
+    f = open(path, 'r')
+    f2 = open(outpath, 'w')
 
-  #1行づつ処理して指定語があったらsplitしてsplit_line[1]を辞書に登録
-  for line in f:
-    line = line.rstrip() 
-    sequence_con += 1
-    sequence_per = (sequence_con / seq)*100
-    if split_str in line:
-      split_line = line.split(split_str)
-      line_cout_str = str(line_cout)
-      linenum_explanation[line_cout_str] = str(split_line[1])
-      line_cout += 1
-    else:
-      line_cout += 1
+    line_cout = 1  # lineのカウントの初期化
+    linenum_explanation = {}  # 行番号:説明文対辞書
 
-    print('■', str(round(sequence_per,2)),'%',end='')
+    # 1行づつ処理して指定語があったらsplitしてsplit_line[1]を辞書に登録
+    for line in f:
+        line = line.rstrip()
+        sequence_con += 1
+        sequence_per = (sequence_con / seq) * 100
+        if split_str in line:
+            split_line = line.split(split_str)
+            line_cout_str = str(line_cout)
+            linenum_explanation[line_cout_str] = str(split_line[1])
+            line_cout += 1
+        else:
+            line_cout += 1
 
-  for line_num in linenum_explanation:
-    f2 = open(outpath, 'a')
-    f2.write(prefix +'\t'+ line_num + ':' + '\t' + linenum_explanation[line_num]+ '\t'+'\t'+'\n'+'\n')
-  f.close()
-  f2.close()
+    print('■', str(round(sequence_per, 2)), '%', end='')
+
+    for line_num in linenum_explanation:
+        f2 = open(outpath, 'a')
+        f2.write('{}\t{}:\t{}\t\t\n\n'.format(
+            prefix, line_num, linenum_explanation[line_num]))
+    f.close()
+    f2.close()

--- a/cjeReportingTool/main.py
+++ b/cjeReportingTool/main.py
@@ -16,7 +16,8 @@ def parseArgs():
                         help='Read file path')
     parser.add_argument('outpath',  metavar='outpath', nargs=1,
                         help='Export file path')
-    parser.add_argument('split_str',  metavar='split_str', nargs='?', default='##',
+    parser.add_argument('split_str', metavar='split_str',
+                        nargs='?', default='##',
                         help='A symbol or string that separates comments from source code')
     parser.add_argument('prefix',  metavar='prefix', nargs='?', default='>',
                         help='A Prefix to be written out')
@@ -26,7 +27,7 @@ def parseArgs():
 def main():
     args = parseArgs()
     c.cjeReportingTool(
-       args.path[0], args.outpath[0], args.split_str, args.prefix)
+        args.path[0], args.outpath[0], args.split_str, args.prefix)
 
 
 if __name__ == "__main__":

--- a/cjeReportingTool/main.py
+++ b/cjeReportingTool/main.py
@@ -1,0 +1,33 @@
+import argparse
+import textwrap
+
+import cjeReportingTool
+
+
+def parseArgs():
+    """Parse arguments."""
+    parser = argparse.ArgumentParser(
+        prog='cjeReportingTool',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent('''\
+        This Tool made for CJE(Chishiki Joho Enshu 3) class at Univ. Tsukuba, klis.
+        This package converts source code comment to markdown text using split words.'''))
+    parser.add_argument('path',  metavar='path', nargs=1,
+                        help='Read file path')
+    parser.add_argument('outpath',  metavar='outpath', nargs=1,
+                        help='Export file path')
+    parser.add_argument('split_str',  metavar='split_str', nargs=1, default='##',
+                        help='A symbol or string that separates comments from source code')
+    parser.add_argument('prefix',  metavar='prefix', nargs=1, default='>',
+                        help='A Prefix to be written out')
+    return parser.parse_args()
+
+
+def main():
+    args = parseArgs()
+    cjeReportingTool.cjeReportingTool(
+       args.path, args.outpath, args.split_str, args.prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/cjeReportingTool/main.py
+++ b/cjeReportingTool/main.py
@@ -1,7 +1,7 @@
 import argparse
 import textwrap
 
-import cjeReportingTool
+import cjeReportingTool.cjeReportingTool as c
 
 
 def parseArgs():
@@ -25,8 +25,8 @@ def parseArgs():
 
 def main():
     args = parseArgs()
-    cjeReportingTool.cjeReportingTool(
-       args.path, args.outpath, args.split_str, args.prefix)
+    c.cjeReportingTool(
+       args.path[0], args.outpath[0], args.split_str, args.prefix)
 
 
 if __name__ == "__main__":

--- a/cjeReportingTool/main.py
+++ b/cjeReportingTool/main.py
@@ -16,9 +16,9 @@ def parseArgs():
                         help='Read file path')
     parser.add_argument('outpath',  metavar='outpath', nargs=1,
                         help='Export file path')
-    parser.add_argument('split_str',  metavar='split_str', nargs=1, default='##',
+    parser.add_argument('split_str',  metavar='split_str', nargs='?', default='##',
                         help='A symbol or string that separates comments from source code')
-    parser.add_argument('prefix',  metavar='prefix', nargs=1, default='>',
+    parser.add_argument('prefix',  metavar='prefix', nargs='?', default='>',
                         help='A Prefix to be written out')
     return parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
     ],
+    entry_points={
+        "console_scripts": [
+            "cjerep=cjeReportingTool.main:main",
+        ]
+    },
 )


### PR DESCRIPTION
#2: コマンドとして呼べるようにした.

```bash
$ pip install cjeReportingTool
$ which cjerep
./.pyenv/versions/3.7.9/bin/cjerep
$ cjerep
usage: cjeReportingTool [-h] path outpath split_str prefix
cjeReportingTool: error: the following arguments are required: path, outpath, split_str, prefix
$ cjerep -h
usage: cjeReportingTool [-h] path outpath split_str prefix

This Tool made for CJE(Chishiki Joho Enshu 3) class at Univ. Tsukuba, klis.
This package converts source code comment to markdown text using split words.

positional arguments:
  path        Read file path
  outpath     Export file path
  split_str   A symbol or string that separates comments from source code
  prefix      A Prefix to be written out

optional arguments:
  -h, --help  show this help message and exit

```